### PR TITLE
use github api

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,11 +180,11 @@ function fetch_readme(opt, cb) {
         }
 
         if (res.body.encoding) {
-            try {
+            if (!Buffer.isEncoding(res.body.encoding)) {
+                return cb(false);
+            } else {
                 var text = Buffer.from(res.body.content, res.body.encoding).toString();
                 return cb(null, text);
-            } catch (e) {
-                return cb(false);
             }
         } else {
             return cb(false);

--- a/index.js
+++ b/index.js
@@ -169,8 +169,9 @@ function count_readme_badges(opt, cb) {
 function fetch_readme(opt, cb) {
     var org = opt.org;
     var repo = opt.repo;
+    var url = printf('https://api.github.com/repos/%s/%s/readme',org,repo);
 
-    request.get('https://api.github.com/repos/'+opt.org+'/'+opt.repo+'/readme').end(function(err, res) {
+    request.get(url).end(function(err, res) {
         if (err) {
             return cb(false);
         }

--- a/index.js
+++ b/index.js
@@ -170,26 +170,25 @@ function fetch_readme(opt, cb) {
     var org = opt.org;
     var repo = opt.repo;
 
-    var base_url = printf('https://raw.githubusercontent.com/%s/%s/master/', org, repo);
-    var readme_variants = ['README.md', 'readme.md', 'Readme.md', 'README.MD', 'readme.markdown'];
-    var readme_text = '';
+    request.get('https://api.github.com/repos/'+opt.org+'/'+opt.repo+'/readme').end(function(err, res) {
+        if (err) {
+            return cb(false);
+        }
 
-    async.some(readme_variants, function(name, cb) {
-        var url = base_url + name;
-        request.get(url).end(function(err, res) {
-            if (err) {
+        if (res.status !== 200) {
+            return cb(false);
+        }
+
+        if (res.body.encoding) {
+            try {
+                var text = Buffer.from(res.body.content, res.body.encoding).toString();
+                return cb(null, text);
+            } catch (e) {
                 return cb(false);
             }
-
-            if (res.status !== 200) {
-                return cb(false);
-            }
-
-            readme_text = res.text;
-            cb(true);
-        });
-    }, function(found) {
-        cb(null, readme_text);
+        } else {
+            return cb(false);
+        }
     });
 }
 


### PR DESCRIPTION
The github api returns the README both as url and base64 encoded. I chose to pick the encoded version.

It's also easily possible to add a parameter for any `ref` now. At line 173 there can be `?ref=` which can be whatever we want, branch, tag ... [source](https://developer.github.com/v3/repos/contents/#parameters).

related to https://github.com/defunctzombie/badginator/issues/9#issuecomment-239028851 (but probably actually not fixing that issue)

This also offloads the detection of readme's to github
